### PR TITLE
Simplified ISPN CM config with the latest JGroups

### DIFF
--- a/openshift-application-slides/Dockerfile
+++ b/openshift-application-slides/Dockerfile
@@ -4,8 +4,6 @@ ENV VERTICLE_FILE openshift-application-slides-1.0-SNAPSHOT-fat.jar
 ENV VERTICLE_HOME /usr/verticles
 
 ENV KUBERNETES_NAMESPACE vertx-openshift-slides
-ENV KUBERNETES_SERVICE_HOST kubernetes.default.svc
-ENV KUBERNETES_SERVICE_PORT 443
 
 EXPOSE 8080
 
@@ -14,4 +12,4 @@ RUN chmod 777 $VERTICLE_HOME
 
 WORKDIR $VERTICLE_HOME
 ENTRYPOINT ["sh", "-c"]
-CMD ["exec java -Dvertx.jgroups.config=default-configs/default-jgroups-kubernetes.xml -DKUBERNETES_NAMESPACE=$KUBERNETES_NAMESPACE -DKUBERNETES_SERVICE_HOST=$KUBERNETES_SERVICE_HOST -DKUBERNETES_SERVICE_PORT=$KUBERNETES_SERVICE_PORT -Djava.net.preferIPv4Stack=true -Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.Log4j2LogDelegateFactory -jar $VERTICLE_FILE -cluster -cp ."]
+CMD ["exec java -Dvertx.jgroups.config=default-configs/default-jgroups-kubernetes.xml -Djava.net.preferIPv4Stack=true -Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.Log4j2LogDelegateFactory -jar $VERTICLE_FILE -cluster -cp ."]

--- a/openshift-examples/C-Eventbus-Producer/Dockerfile
+++ b/openshift-examples/C-Eventbus-Producer/Dockerfile
@@ -4,8 +4,6 @@ ENV JAR C-Eventbus-Producer-1.0-SNAPSHOT-fat.jar
 ENV APP_HOME /usr/vertx
 
 ENV KUBERNETES_NAMESPACE vertx-openshift-slides
-ENV KUBERNETES_SERVICE_HOST kubernetes.default.svc
-ENV KUBERNETES_SERVICE_PORT 443
 
 EXPOSE 8080
 
@@ -15,4 +13,4 @@ RUN chmod 777 $APP_HOME
 
 WORKDIR $APP_HOME
 ENTRYPOINT ["sh", "-c"]
-CMD ["exec java -Dvertx.jgroups.config=default-configs/default-jgroups-kubernetes.xml -DKUBERNETES_NAMESPACE=$KUBERNETES_NAMESPACE -DKUBERNETES_SERVICE_HOST=$KUBERNETES_SERVICE_HOST -DKUBERNETES_SERVICE_PORT=$KUBERNETES_SERVICE_PORT -Djava.net.preferIPv4Stack=true -Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.Log4j2LogDelegateFactory -jar $JAR -cluster -cp ."]
+CMD ["exec java -Dvertx.jgroups.config=default-configs/default-jgroups-kubernetes.xml -Djava.net.preferIPv4Stack=true -Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.Log4j2LogDelegateFactory -jar $JAR -cluster -cp ."]

--- a/openshift-examples/F-Load-Balancing/Dockerfile
+++ b/openshift-examples/F-Load-Balancing/Dockerfile
@@ -4,8 +4,6 @@ ENV JAR F-Load-Balancing-1.0-SNAPSHOT-fat.jar
 ENV APP_HOME /usr/vertx
 
 ENV KUBERNETES_NAMESPACE vertx-openshift-slides
-ENV KUBERNETES_SERVICE_HOST kubernetes.default.svc
-ENV KUBERNETES_SERVICE_PORT 443
 
 EXPOSE 8080
 
@@ -14,4 +12,4 @@ RUN chmod 777 $APP_HOME
 
 WORKDIR $APP_HOME
 ENTRYPOINT ["sh", "-c"]
-CMD ["exec java -Dvertx.jgroups.config=default-configs/default-jgroups-kubernetes.xml -DKUBERNETES_NAMESPACE=$KUBERNETES_NAMESPACE -DKUBERNETES_SERVICE_HOST=$KUBERNETES_SERVICE_HOST -DKUBERNETES_SERVICE_PORT=$KUBERNETES_SERVICE_PORT -Djava.net.preferIPv4Stack=true -Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.Log4j2LogDelegateFactory -jar $JAR -cluster -cp ."]
+CMD ["exec java -Dvertx.jgroups.config=default-configs/default-jgroups-kubernetes.xml -Djava.net.preferIPv4Stack=true -Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.Log4j2LogDelegateFactory -jar $JAR -cluster -cp ."]

--- a/openshift-examples/pom.xml
+++ b/openshift-examples/pom.xml
@@ -55,6 +55,12 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-infinispan</artifactId>
+      <exclusions>
+        <exclusion>
+          <artifactId>jgroups</artifactId>
+          <groupId>org.jgroups</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.infinispan</groupId>
@@ -71,12 +77,6 @@
       <groupId>org.jgroups.kubernetes</groupId>
       <artifactId>jgroups-kubernetes</artifactId>
       <version>1.0.0.Beta1</version>
-      <exclusions>
-        <exclusion>
-          <artifactId>jgroups</artifactId>
-          <groupId>org.jgroups</groupId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,12 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-infinispan</artifactId>
+      <exclusions>
+        <exclusion>
+          <artifactId>jgroups</artifactId>
+          <groupId>org.jgroups</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.infinispan</groupId>
@@ -64,12 +70,6 @@
       <groupId>org.jgroups.kubernetes</groupId>
       <artifactId>jgroups-kubernetes</artifactId>
       <version>1.0.0.Beta1</version>
-      <exclusions>
-        <exclusion>
-          <artifactId>jgroups</artifactId>
-          <groupId>org.jgroups</groupId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Environment variables were not resolved because support was added
in a more recent version than the version which comes with ISPN